### PR TITLE
Fix IndentationError in panels.py and add get_data_path to config_man…

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -103,6 +103,28 @@ def set_config_value(key: str, value: Any):
     save_config(config)
 
 
+def get_data_path() -> str:
+    """
+    Restituisce il percorso base per i dati (es. Licenza).
+    Cerca prima in CONFIG_DIR (AppData), poi nel root del progetto.
+
+    Returns:
+        Path della directory dati
+    """
+    # 1. Cerca in CONFIG_DIR (AppData)
+    if (CONFIG_DIR / "Licenza").exists():
+        return str(CONFIG_DIR)
+
+    # 2. Cerca nel root del progetto
+    # src/core/config_manager.py -> src/core -> src -> root
+    project_root = Path(__file__).resolve().parent.parent.parent
+    if (project_root / "Licenza").exists():
+        return str(project_root)
+
+    # 3. Default: CONFIG_DIR
+    return str(CONFIG_DIR)
+
+
 def get_download_path() -> str:
     """
     Restituisce il path di download configurato.

--- a/src/gui/panels.py
+++ b/src/gui/panels.py
@@ -386,8 +386,8 @@ class ScaricaTSPanel(BaseBotPanel):
             if index >= 0:
                 self.fornitore_combo.setCurrentIndex(index)
             else:
-            # Seleziona il primo elemento
-            self.fornitore_combo.setCurrentIndex(0)
+                # Seleziona il primo elemento
+                self.fornitore_combo.setCurrentIndex(0)
     
     def _load_saved_data(self):
         """Carica i dati salvati."""


### PR DESCRIPTION
…ager.py

- Corrected indentation in `src/gui/panels.py` to fix syntax error.
- Implemented `get_data_path` in `src/core/config_manager.py` to resolve AttributeError, implementing fallback logic for data path resolution (AppData -> Project Root).