### PR TITLE
Fix DettagliOdA nav/logout and ScaricoTS renaming

### DIFF
--- a/src/bots/dettagli_oda/bot.py
+++ b/src/bots/dettagli_oda/bot.py
@@ -71,7 +71,8 @@ class DettagliOdABot(BaseBot):
             self.log(f"Riga {i}: OdA={oda}, Contratto={contract}")
 
             # Navigate and Setup for each row as required by the workflow (resetting tabs)
-            if not page.navigate_to_dettagli():
+            # Pass (i==1) to let the page know if it's the first row
+            if not page.navigate_to_dettagli(is_first_row=(i==1)):
                 self.log("✗ Fallita navigazione iniziale per la riga.")
                 continue
             if not page.setup_supplier(self.fornitore):

--- a/src/bots/dettagli_oda/locators.py
+++ b/src/bots/dettagli_oda/locators.py
@@ -36,3 +36,7 @@ class DettagliOdALocators:
 
     # Tabs
     TAB_CLOSE_BTN = (By.XPATH, "//*[contains(@class, 'x-tab-close-btn')]")
+
+    # Logout Specifics
+    LOGOUT_SETTINGS_BUTTON = (By.ID, "user-info-settings")
+    LOGOUT_CONFIRM_YES = (By.XPATH, "//span[text()='Si' and contains(@class, 'x-btn-inner')]")

--- a/src/bots/scarico_ts/bot.py
+++ b/src/bots/scarico_ts/bot.py
@@ -307,7 +307,8 @@ class ScaricaTSBot(BaseBot):
                 safe_pos = sanitize_filename(posizione_oda)
                 
                 # Formato richiesto: TS_{oda}-{pos}.xlsx
-                if safe_pos:
+                # sanitize_filename returns "unnamed_file" for empty strings, so we check for that too
+                if safe_pos and safe_pos != "unnamed_file":
                     nuovo_nome_base = f"TS_{safe_oda}-{safe_pos}"
                 else:
                     nuovo_nome_base = f"TS_{safe_oda}"


### PR DESCRIPTION
- Scarico TS: Explicitly check for 'unnamed_file' from sanitize_filename to correctly format files without position suffix (`TS_{oda}.xlsx`).
- Dettagli OdA:
    - Implemented double-click logic for the 'Report' menu from the second row onwards to ensure navigation works reliably.
    - Updated logout selectors to match specific IDs provided (`user-info-settings`) and confirmation button text.
    - Added specific locators in `DettagliOdALocators`.
- Updated tests to cover navigation logic changes.